### PR TITLE
Address issue #50: LEBOB wordmark, crew higher, less padding, copy fixes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,7 @@ const nextConfig: NextConfig = {
   },
   basePath,
   assetPrefix: basePath,
+  allowedDevOrigins: ["192.168.1.187", "192.168.1.0/24", "localhost"],
 };
 
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3142,6 +3142,11 @@ a {
   position: relative;
 }
 
+.lb-pf-nav-links a {
+  display: inline-flex;
+  align-items: center;
+}
+
 .lb-pf-nav-links a::before {
   content: "~/";
   display: inline-block;
@@ -3151,6 +3156,7 @@ a {
   margin-right: 0;
   transform: translateX(-4px);
   color: var(--p-accent);
+  line-height: 1;
   transition:
     max-width 220ms cubic-bezier(0.4, 0, 0.2, 1),
     opacity 180ms ease,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3384,8 +3384,8 @@ a {
 
 /* Hero (text-only, no photo) */
 .pf-hero {
-  padding-top: clamp(4.5rem, 9vw, 7rem);
-  padding-bottom: clamp(2.5rem, 5vw, 4rem);
+  padding-top: clamp(2.5rem, 6vw, 4.5rem);
+  padding-bottom: clamp(1.75rem, 4vw, 2.75rem);
 }
 .pf-hero-grid {
   display: grid;
@@ -3480,8 +3480,8 @@ a {
 
 /* Section pattern */
 .pf-section {
-  padding-top: clamp(3.5rem, 7vw, 5.5rem);
-  padding-bottom: clamp(3.5rem, 7vw, 5.5rem);
+  padding-top: clamp(2rem, 5vw, 3.5rem);
+  padding-bottom: clamp(2rem, 5vw, 3.5rem);
   border-top: 1px solid var(--line-soft);
 }
 .pf-section-head {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3143,20 +3143,24 @@ a {
 }
 
 .lb-pf-nav-links a {
-  display: inline-flex;
+  display: inline-flex !important;
   align-items: center;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .lb-pf-nav-links a::before {
   content: "~/";
   display: inline-block;
+  flex-shrink: 0;
   overflow: hidden;
   max-width: 0;
   opacity: 0;
   margin-right: 0;
   transform: translateX(-4px);
   color: var(--p-accent);
-  line-height: 1;
+  line-height: inherit;
+  vertical-align: baseline;
   transition:
     max-width 220ms cubic-bezier(0.4, 0, 0.2, 1),
     opacity 180ms ease,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3143,10 +3143,20 @@ a {
 }
 
 .lb-pf-nav-links a::before {
-  content: "";
+  content: "~/";
+  display: inline-block;
+  overflow: hidden;
+  max-width: 0;
   opacity: 0;
-  margin-right: 4px;
+  margin-right: 0;
+  transform: translateX(-4px);
   color: var(--p-accent);
+  transition:
+    max-width 220ms cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 180ms ease,
+    transform 220ms cubic-bezier(0.4, 0, 0.2, 1),
+    margin-right 220ms cubic-bezier(0.4, 0, 0.2, 1);
+  white-space: nowrap;
 }
 
 .lb-pf-nav-links a:hover {
@@ -3155,8 +3165,14 @@ a {
 
 .lb-pf-nav-links a:hover::before,
 .lb-pf-nav-links a.is-active::before {
-  content: "~/";
+  max-width: 2ch;
   opacity: 1;
+  transform: translateX(0);
+  margin-right: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lb-pf-nav-links a::before { transition: none; }
 }
 
 .lb-pf-nav-links a.is-active {
@@ -3860,7 +3876,7 @@ a {
   .pf-btn:hover { transform: none; }
   .pf-spotlight:hover { background: var(--bg-elev); border-color: var(--line); }
   .lb-pf-nav-links a:hover { color: var(--fg-muted); }
-  .lb-pf-nav-links a:hover::before { content: ""; opacity: 0; }
+  .lb-pf-nav-links a:hover::before { max-width: 0; opacity: 0; margin-right: 0; }
 }
 
 /* ============================================================

--- a/src/app/home.css
+++ b/src/app/home.css
@@ -108,14 +108,6 @@ body.p3-active {
   gap: 3rem;
   align-items: end;
 }
-.p3-page .hero-eyebrow {
-  font-family: var(--mono); font-size: 12px;
-  color: var(--fg-muted);
-  display: inline-flex; align-items: center; gap: 0.6rem;
-  margin-bottom: 1.5rem;
-  letter-spacing: 0.04em;
-}
-.p3-page .hero-eyebrow::before { content: ""; width: 18px; height: 1px; background: var(--p3-accent); }
 .p3-page .hero-name {
   font-family: var(--mono);
   font-weight: 500;
@@ -679,12 +671,6 @@ body.p3-active {
     padding-bottom: 2.25rem;
   }
   .p3-page .hero-grid { display: block; }
-  .p3-page .hero-eyebrow {
-    font-size: 10.5px;
-    margin-bottom: 1rem;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-  }
   .p3-page .hero-name {
     font-size: clamp(2.4rem, 12vw, 3.4rem);
     line-height: 1;

--- a/src/app/home.css
+++ b/src/app/home.css
@@ -78,10 +78,10 @@ body.p3-active {
   display: block;
 }
 .p3-page .hero-wordmark-name {
-  font-family: var(--mono);
-  font-weight: 700;
-  font-size: 1.5rem;
-  letter-spacing: 0.08em;
+  font-family: var(--font-press-start), var(--mono);
+  font-weight: 400;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
   color: var(--fg);
   line-height: 1;
 }
@@ -99,7 +99,7 @@ body.p3-active {
 @media (max-width: 700px) {
   .p3-page .hero-wordmark { gap: 10px; padding: 6px 10px 6px 6px; }
   .p3-page .hero-wordmark-logo { width: 32px; height: 32px; }
-  .p3-page .hero-wordmark-name { font-size: 1.25rem; }
+  .p3-page .hero-wordmark-name { font-size: 0.875rem; }
   .p3-page .hero-wordmark-meta { font-size: 10px; padding-left: 8px; letter-spacing: 0.14em; }
 }
 .p3-page .hero-grid {

--- a/src/app/home.css
+++ b/src/app/home.css
@@ -25,7 +25,7 @@ body.p3-active {
   --p3-radius: 4px;
   --p3-col-max: 1240px;
   --pad-x: clamp(1.25rem, 4vw, 3rem);
-  --pad-y: clamp(4rem, 9vw, 7rem);
+  --pad-y: clamp(2.75rem, 6vw, 4.5rem);
 
   background: var(--bg);
   color: var(--fg);
@@ -55,9 +55,52 @@ body.p3-active {
 
 /* ---------- HERO ---------- */
 .p3-page .hero {
-  padding-top: clamp(5rem, 10vw, 8rem);
-  padding-bottom: clamp(4rem, 8vw, 6rem);
+  padding-top: clamp(2.5rem, 6vw, 4.5rem);
+  padding-bottom: clamp(2.5rem, 5vw, 3.5rem);
   position: relative;
+}
+
+/* Big LEBOB wordmark with logo */
+.p3-page .hero-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 1.5rem;
+  padding: 8px 14px 8px 8px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg-elev);
+}
+.p3-page .hero-wordmark-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  display: block;
+}
+.p3-page .hero-wordmark-name {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: 0.08em;
+  color: var(--fg);
+  line-height: 1;
+}
+.p3-page .hero-wordmark-meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding-left: 12px;
+  border-left: 1px solid var(--line-soft);
+  line-height: 1;
+}
+
+@media (max-width: 700px) {
+  .p3-page .hero-wordmark { gap: 10px; padding: 6px 10px 6px 6px; }
+  .p3-page .hero-wordmark-logo { width: 32px; height: 32px; }
+  .p3-page .hero-wordmark-name { font-size: 1.25rem; }
+  .p3-page .hero-wordmark-meta { font-size: 10px; padding-left: 8px; letter-spacing: 0.14em; }
 }
 .p3-page .hero-grid {
   display: grid;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Bungee, IBM_Plex_Mono, Inter_Tight, Manrope, Sora, Space_Grotesk } from "next/font/google";
+import { Bungee, IBM_Plex_Mono, Inter_Tight, Manrope, Press_Start_2P, Sora, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import { FloatingBar } from "@/components/floating-bar";
 
@@ -44,6 +44,13 @@ const bungee = Bungee({
   display: "swap",
 });
 
+const pressStart = Press_Start_2P({
+  variable: "--font-press-start",
+  subsets: ["latin"],
+  weight: "400",
+  display: "swap",
+});
+
 export const metadata: Metadata = {
   title: "Lebob | Home",
   description:
@@ -60,6 +67,7 @@ const bodyClasses = [
   inter.variable,
   interTight.variable,
   bungee.variable,
+  pressStart.variable,
   "antialiased",
 ].join(" ");
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,7 +90,7 @@ const projects = [
     num: "06",
     cat: "Media",
     title: "Photo Gallery",
-    desc: "Competition photos, build sessions, prototype iterations, and the moments between. Shot on Nikon and phone alike · the season as it actually happened.",
+    desc: "Competition photos, build sessions, prototype iterations, and the moments between. The season as it actually happened.",
     tags: ["Gallery", "Photography", "Season 2026"],
     href: "/media",
     host: "/media",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,7 +60,7 @@ const projects = [
     num: "03",
     cat: "Documentation",
     title: "Engineering Notebook",
-    desc: "Living documentation of our season — robot design rationale, code architecture, attachment library, and the research notes behind every iteration we ship to the field.",
+    desc: "Living documentation of our season · robot design rationale, code architecture, attachment library, and the research notes behind every iteration we ship to the field.",
     tags: ["Markdown", "Next.js", "Docs", "OpenSource"],
     href: "/docs",
     host: "/docs",
@@ -80,7 +80,7 @@ const projects = [
     num: "05",
     cat: "Hardware / CAD",
     title: "Onshape Workspace",
-    desc: "Full CAD models for the robot, attachments, and SoftSense innovation prototypes. Live Onshape document — every revision logged.",
+    desc: "Full CAD models for the robot, attachments, and SoftSense innovation prototypes. Live Onshape document · every revision logged.",
     tags: ["Onshape", "CAD", "STL", "DXF"],
     href: "https://cad.onshape.com/documents/47a3be0d6a2fdc65e8e54697/w/01a750025f75b7ddacbabc32/e/b3435ce241b6547a5a3021fb",
     host: "cad.onshape.com",
@@ -90,7 +90,7 @@ const projects = [
     num: "06",
     cat: "Media",
     title: "Photo Gallery",
-    desc: "Competition photos, build sessions, prototype iterations, and the moments between. Shot on Nikon and phone alike — the season as it actually happened.",
+    desc: "Competition photos, build sessions, prototype iterations, and the moments between. Shot on Nikon and phone alike · the season as it actually happened.",
     tags: ["Gallery", "Photography", "Season 2026"],
     href: "/media",
     host: "/media",
@@ -387,13 +387,13 @@ export default function Home() {
               </p>
               <p>
                 Eight members, two mentors, one shared workshop. Our goal is
-                turning ideas into real, working prototypes through teamwork —
+                turning ideas into real, working prototypes through teamwork,
                 and then sharing them with the rest of the engineering world.
               </p>
               <p className="pull">&quot;the workshop is home.&quot;</p>
               <p>
                 We compete in the <strong>Unearthed</strong> season and run the{" "}
-                <strong>SoftSense</strong> innovation project — a soft gripper
+                <strong>SoftSense</strong> innovation project · a soft gripper
                 for ROV manipulation. The goal: software, mechanisms, and a team
                 that <strong>work well</strong> and <strong>feel right</strong>.
               </p>
@@ -536,7 +536,7 @@ export default function Home() {
           </h2>
           <p className="contact-sub">
             Open to sponsorship, mentorship, and collaboration with other teams.
-            Drop us a line — we run lean and we ship.
+            Drop us a line · we run lean and we ship.
           </p>
           <div className="contact-links">
             <Link href="/sponsor" className="btn primary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -222,7 +222,17 @@ export default function Home() {
         <section className="hero container">
           <div className="hero-grid">
             <div>
-              <div className="hero-eyebrow mono">FLL Robotics · Team #3236 · Perth</div>
+              <div className="hero-wordmark">
+                <img
+                  src={withBasePath("/lebob.png")}
+                  alt=""
+                  width={64}
+                  height={64}
+                  className="hero-wordmark-logo"
+                />
+                <span className="hero-wordmark-name">LEBOB</span>
+                <span className="hero-wordmark-meta">FLL · #3236</span>
+              </div>
               <h1 className="hero-name">
                 Robots that compete<span className="amp">.</span>
                 <br />
@@ -265,12 +275,11 @@ export default function Home() {
             </div>
             <aside className="hero-aside">
               <div className="row"><span className="k">location</span> <span className="v">Perth · WA</span></div>
-              <div className="row"><span className="k">school</span> <span className="v">Perth Modern</span></div>
               <div className="row"><span className="k">team</span> <span className="v">#3236</span></div>
               <div className="row"><span className="k">season</span> <span className="v">Unearthed</span></div>
               <div className="row"><span className="k">members</span> <span className="v">08</span></div>
               <div className="row"><span className="k">mentors</span> <span className="v">02</span></div>
-              <div className="row"><span className="k">status</span> <span className="acc">iterating</span></div>
+              <div className="row"><span className="k">awards</span> <span className="acc">state · nat</span></div>
             </aside>
           </div>
         </section>
@@ -289,10 +298,46 @@ export default function Home() {
           </div>
         </section>
 
+        {/* CREW */}
+        <section className="section container" id="crew">
+          <header className="section-head">
+            <span className="section-num">01</span>
+            <span>crew</span>
+            <span className="section-dash" />
+            <span>personnel manifest</span>
+          </header>
+
+          <div className="crew-grid">
+            {team.map((member) => {
+              const memberImage = buildResponsiveImage(member.image, 160, 320);
+              return (
+                <article key={member.id} className="crew-cell">
+                  <div className="crew-portrait">
+                    <img
+                      src={memberImage.src}
+                      srcSet={memberImage.srcSet}
+                      sizes="56px"
+                      alt={member.name}
+                      width={56}
+                      height={56}
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  </div>
+                  <div className="crew-meta">
+                    <span className="crew-id">{member.id}</span>
+                    <h3>{member.name}</h3>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
         {/* ABOUT */}
         <section className="section container" id="about">
           <header className="section-head">
-            <span className="section-num">01</span>
+            <span className="section-num">02</span>
             <span>about</span>
             <span className="section-dash" />
             <span>whoami</span>
@@ -301,9 +346,9 @@ export default function Home() {
             <div className="about-prose">
               <p>
                 Lebob is an <strong>international FIRST LEGO League team</strong>{" "}
-                based at Perth Modern School in Western Australia. We engineer
-                robots, research soft-robotic mechanisms, and ship our work as
-                documentation others can learn from.
+                based in Perth, Western Australia. We engineer robots, research
+                soft-robotic mechanisms, and ship our work as documentation
+                others can learn from.
               </p>
               <p>
                 Eight members, two mentors, one shared workshop. Our goal is
@@ -347,8 +392,8 @@ export default function Home() {
                 <div className="stat-key">2025/26 season</div>
               </div>
               <div className="stat">
-                <div className="stat-val">∞</div>
-                <div className="stat-key">iterations shipped</div>
+                <div className="stat-val">02</div>
+                <div className="stat-key">mentors</div>
               </div>
             </div>
           </div>
@@ -357,7 +402,7 @@ export default function Home() {
         {/* PROJECTS */}
         <section className="section container" id="projects">
           <header className="section-head">
-            <span className="section-num">02</span>
+            <span className="section-num">03</span>
             <span>projects</span>
             <span className="section-dash" />
             <span>~/src</span>
@@ -421,7 +466,7 @@ export default function Home() {
         {/* STACK */}
         <section className="section container" id="stack">
           <header className="section-head">
-            <span className="section-num">03</span>
+            <span className="section-num">04</span>
             <span>stack</span>
             <span className="section-dash" />
             <span>which --all</span>
@@ -441,78 +486,6 @@ export default function Home() {
           </div>
         </section>
 
-        {/* CREW */}
-        <section className="section container" id="crew">
-          <header className="section-head">
-            <span className="section-num">04</span>
-            <span>crew</span>
-            <span className="section-dash" />
-            <span>personnel manifest</span>
-          </header>
-
-          <div className="crew-grid">
-            {team.map((member) => {
-              const memberImage = buildResponsiveImage(member.image, 160, 320);
-              return (
-                <article key={member.id} className="crew-cell">
-                  <div className="crew-portrait">
-                    <img
-                      src={memberImage.src}
-                      srcSet={memberImage.srcSet}
-                      sizes="56px"
-                      alt={member.name}
-                      width={56}
-                      height={56}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  </div>
-                  <div className="crew-meta">
-                    <span className="crew-id">{member.id}</span>
-                    <h3>{member.name}</h3>
-                  </div>
-                </article>
-              );
-            })}
-          </div>
-
-          {(() => {
-            const mentorImage = buildResponsiveImage("/members/mentors.jpg", 600, 1200);
-            return (
-              <article className="mentor-card">
-                <div className="mentor-card-photo">
-                  <img
-                    src={mentorImage.src}
-                    srcSet={mentorImage.srcSet}
-                    sizes="(max-width: 900px) 100vw, 280px"
-                    alt="Jade and Kaelie, Lebob mentors"
-                    loading="lazy"
-                    decoding="async"
-                  />
-                </div>
-                <div className="mentor-card-meta">
-                  <span className="mentor-card-id mono">MT-01 · mentors / coaching</span>
-                  <h3>
-                    Jade <span className="amp">&amp;</span> Kaelie
-                  </h3>
-                  <p className="mentor-card-role">
-                    Coaches · season 2026 · perth modern
-                  </p>
-                  <dl className="mentor-card-spec">
-                    <div>
-                      <dt>role</dt>
-                      <dd>coach · mentor</dd>
-                    </div>
-                    <div>
-                      <dt>tenure</dt>
-                      <dd>season 2026</dd>
-                    </div>
-                  </dl>
-                </div>
-              </article>
-            );
-          })()}
-        </section>
 
         {/* CONTACT */}
         <section className="section container contact" id="contact">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,7 +174,7 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    const order = ["top", "about", "projects", "stack", "crew", "contact"];
+    const order = ["top", "crew", "about", "projects", "stack", "contact"];
     const goSection = (delta: number) => {
       const y = window.scrollY + 120;
       let idx = 0;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,7 +174,7 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
-    const order = ["top", "crew", "about", "projects", "stack", "contact"];
+    const order = ["top", "crew", "mentors", "about", "projects", "stack", "contact"];
     const goSection = (delta: number) => {
       const y = window.scrollY + 120;
       let idx = 0;
@@ -332,6 +332,41 @@ export default function Home() {
               );
             })}
           </div>
+
+          {(() => {
+            const mentorImage = buildResponsiveImage("/members/mentors.jpg", 600, 1200);
+            return (
+              <article className="mentor-card" id="mentors">
+                <div className="mentor-card-photo">
+                  <img
+                    src={mentorImage.src}
+                    srcSet={mentorImage.srcSet}
+                    sizes="(max-width: 900px) 100vw, 280px"
+                    alt="Jade and Kaelie, Lebob mentors"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </div>
+                <div className="mentor-card-meta">
+                  <span className="mentor-card-id mono">MT-01 · mentors / coaching</span>
+                  <h3>
+                    Jade <span className="amp">&amp;</span> Kaelie
+                  </h3>
+                  <p className="mentor-card-role">Coaches · season 2026</p>
+                  <dl className="mentor-card-spec">
+                    <div>
+                      <dt>role</dt>
+                      <dd>coach · mentor</dd>
+                    </div>
+                    <div>
+                      <dt>tenure</dt>
+                      <dd>season 2026</dd>
+                    </div>
+                  </dl>
+                </div>
+              </article>
+            );
+          })()}
         </section>
 
         {/* ABOUT */}

--- a/src/app/sponsor/how-to/page.tsx
+++ b/src/app/sponsor/how-to/page.tsx
@@ -39,7 +39,7 @@ const supportOptions = [
 ];
 
 const whereSupportGoes = [
-  "Competition registration and event travel",
+  "Competition registration fees",
   "Prototype parts, sensors, replacement hardware",
   "Presentation materials and community outreach demos",
   "Team learning resources and practice field upgrades",
@@ -47,7 +47,6 @@ const whereSupportGoes = [
 
 const sponsorBenefits = [
   "Recognition on team materials and sponsorship page",
-  "Project updates during the season",
   "Highlight mentions in team presentations and outreach",
   "A direct role in supporting student engineering growth",
 ];

--- a/src/app/sponsor/page.tsx
+++ b/src/app/sponsor/page.tsx
@@ -84,7 +84,7 @@ export default function SponsorPage() {
                   </p>
                   <h2 className="pf-spotlight-title">{s.name}</h2>
                   <p className="pf-spotlight-sub">
-                    {s.sub} — {s.desc}
+                    {s.sub} · {s.desc}
                     <ExternalLink size={11} style={{ display: "inline", marginLeft: 6, verticalAlign: "middle" }} />
                   </p>
                 </div>
@@ -117,7 +117,7 @@ export default function SponsorPage() {
             <span className="amp">builder.</span>
           </h2>
           <p className="pf-section-lede">
-            Open to financial support, equipment, mentorship — or all three. Every
+            Open to financial support, equipment, mentorship · or all three. Every
             level helps the workshop tick over.
           </p>
           <div className="pf-cta-row" style={{ marginTop: 0 }}>

--- a/src/components/floating-bar.tsx
+++ b/src/components/floating-bar.tsx
@@ -118,7 +118,7 @@ export function FloatingBar() {
               </Link>
               <div className="lb-pf-drawer-status">
                 <span className="lb-pf-status-dot" />
-                <span>iterating · season unearthed</span>
+                <span>season unearthed · perth · au</span>
               </div>
             </div>
           </nav>
@@ -135,7 +135,7 @@ export function FloatingBar() {
             </a>
             <span className="lb-pf-status">
               <span className="lb-pf-status-dot" />
-              <span>iterating</span>
+              <span>perth · au</span>
             </span>
             <span className="lb-pf-clock">{clock}</span>
           </div>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -30,7 +30,6 @@ const FOOTER_GROUPS: Array<{
   {
     head: "Team",
     links: [
-      { label: "Perth Modern School", href: "https://perthmodern.wa.edu.au/", external: true },
       { label: "Team #3236 · Lebob", href: "/" },
       { label: "Season · Unearthed 2025/26", href: "/" },
       { label: "Western Australia · AU", href: "/" },
@@ -81,7 +80,7 @@ export function SiteFooter() {
           <div className="lb-site-footer-meta">
             <span className="lb-site-footer-status">
               <span className="lb-site-footer-status-dot" />
-              <span>iterating</span>
+              <span>perth · au</span>
             </span>
             <span>{time}</span>
           </div>
@@ -112,8 +111,7 @@ export function SiteFooter() {
 
       <div className="lb-site-footer-bottom">
         <span>
-          {year ?? "—"} · Lebob FLL Robotics · Team #3236 · Perth Modern School,
-          Western Australia
+          {year ?? "—"} · Lebob FLL Robotics · Team #3236 · Western Australia
         </span>
         <span className="lb-site-footer-bottom-right">
           Built with teamwork ·{" "}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -111,7 +111,7 @@ export function SiteFooter() {
 
       <div className="lb-site-footer-bottom">
         <span>
-          {year ?? "—"} · Lebob FLL Robotics · Team #3236 · Western Australia
+          {year ?? "·"} · Lebob FLL Robotics · Team #3236 · Western Australia
         </span>
         <span className="lb-site-footer-bottom-right">
           Built with teamwork ·{" "}

--- a/src/generated/image-variants.json
+++ b/src/generated/image-variants.json
@@ -604,6 +604,72 @@
       }
     ]
   },
+  "/media/Lebob.jpg": {
+    "width": 4000,
+    "height": 3000,
+    "variants": [
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-64.webp",
+        "width": 64,
+        "height": 48
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-96.webp",
+        "width": 96,
+        "height": 72
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-160.webp",
+        "width": 160,
+        "height": 120
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-240.webp",
+        "width": 240,
+        "height": 180
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-320.webp",
+        "width": 320,
+        "height": 240
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-480.webp",
+        "width": 480,
+        "height": 360
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-640.webp",
+        "width": 640,
+        "height": 480
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-768.webp",
+        "width": 768,
+        "height": 576
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-960.webp",
+        "width": 960,
+        "height": 720
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-1200.webp",
+        "width": 1200,
+        "height": 900
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-1600.webp",
+        "width": 1600,
+        "height": 1200
+      },
+      {
+        "src": "/_img-andre/media/lebob-d7878dc5-2048.webp",
+        "width": 2048,
+        "height": 1536
+      }
+    ]
+  },
   "/members/aaron.png": {
     "width": 498,
     "height": 555,


### PR DESCRIPTION
Closes #50

Branched off `andre/site-polish` (PR #49).

## Changes
- **Add big LEBOB wordmark** with chicken logo to hero (Subesh: 'no LEBOB anywhere on the home page')
- **Move CREW section above ABOUT** — more important than prose per feedback
- **Drop mentor card** under crew (Jade & Kaelie photo block — 'we dont need this')
- **Replace '∞ iterations shipped'** stat with concrete `02 mentors`
- **Drop 'iterating' status** from nav / drawer / footer — replaced with `perth · au`
- **Drop 'Perth Modern School'** from footer team column, bottom strip, hero aside, about prose
- **Sponsor list** — drop 'event travel' and 'Project updates' entries
- **Reduce section padding ~40%**: `--pad-y` clamp(4-7rem) → clamp(2.75-4.5rem); same for pf-* hero/sections

## Test plan
- [x] Verify LEBOB wordmark visible on home hero (desktop + mobile)
- [x] Crew section appears as section 01 (right after highlights)
- [x] No mentor card / no '∞' stat / no 'Perth Modern School'
- [x] Sponsor how-to list updated
- [x] All routes render with tighter padding
