### PR TITLE
Apply Emil Kowalski design-engineering polish + clean home URL

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -171,9 +171,9 @@
 <body>
   <nav class="nav">
     <div class="container nav-inner">
-      <a href="index.html" class="nav-brand"><img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo"><span>Lebob</span></a>
+      <a href="/" class="nav-brand"><img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo"><span>Lebob</span></a>
       <ul class="nav-links">
-        <li><a href="index.html">Home</a></li><li><a href="media.html">Media</a></li>
+        <li><a href="/">Home</a></li><li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li><li><a href="sponsor.html">Sponsors</a></li>
         <li><a href="sponsor-how-to.html" class="nav-cta">Sponsor Lebob</a></li>
       </ul>
@@ -185,7 +185,7 @@
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu">
-    <a href="index.html">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
+    <a href="/">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
     <a href="sponsor.html">Sponsors</a><a href="sponsor-how-to.html">Sponsor Lebob</a>
   </div>
 
@@ -293,7 +293,7 @@
     <div class="container footer-inner">
       <div class="footer-left">© 2025 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
-        <li><a href="index.html">Home</a></li><li><a href="media.html">Media</a></li>
+        <li><a href="/">Home</a></li><li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li><li><a href="sponsor.html">Sponsors</a></li>
       </ul>
     </div>

--- a/docs.html
+++ b/docs.html
@@ -165,6 +165,8 @@
     }
     @media (max-width: 480px) { .container { padding: 0 16px; } }
   </style>
+  <link rel="stylesheet" href="polish.css">
+  <script src="polish.js" defer></script>
 </head>
 <body>
   <nav class="nav">

--- a/index.html
+++ b/index.html
@@ -514,6 +514,8 @@
       .hero-meta { flex-wrap: wrap; justify-content: center; }
     }
   </style>
+  <link rel="stylesheet" href="polish.css">
+  <script src="polish.js" defer></script>
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -522,12 +522,12 @@
   <!-- NAV -->
   <nav class="nav">
     <div class="container nav-inner">
-      <a href="index.html" class="nav-brand">
+      <a href="/" class="nav-brand">
         <img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo">
         <span>Lebob</span>
       </a>
       <ul class="nav-links">
-        <li><a href="index.html">Home</a></li>
+        <li><a href="/">Home</a></li>
         <li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li>
         <li><a href="sponsor.html">Sponsors</a></li>
@@ -544,7 +544,7 @@
   </nav>
 
   <div class="mobile-menu" id="mobileMenu">
-    <a href="index.html">Home</a>
+    <a href="/">Home</a>
     <a href="media.html">Media</a>
     <a href="docs.html">Docs</a>
     <a href="sponsor.html">Sponsors</a>
@@ -785,7 +785,7 @@
         © 2025 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a>
       </div>
       <ul class="footer-links">
-        <li><a href="index.html">Home</a></li>
+        <li><a href="/">Home</a></li>
         <li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li>
         <li><a href="sponsor.html">Sponsors</a></li>

--- a/media.html
+++ b/media.html
@@ -141,6 +141,8 @@
       .container { padding: 0 16px; }
     }
   </style>
+  <link rel="stylesheet" href="polish.css">
+  <script src="polish.js" defer></script>
 </head>
 <body>
   <nav class="nav">

--- a/media.html
+++ b/media.html
@@ -147,9 +147,9 @@
 <body>
   <nav class="nav">
     <div class="container nav-inner">
-      <a href="index.html" class="nav-brand"><img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo"><span>Lebob</span></a>
+      <a href="/" class="nav-brand"><img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo"><span>Lebob</span></a>
       <ul class="nav-links">
-        <li><a href="index.html">Home</a></li><li><a href="media.html">Media</a></li>
+        <li><a href="/">Home</a></li><li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li><li><a href="sponsor.html">Sponsors</a></li>
         <li><a href="sponsor-how-to.html" class="nav-cta">Sponsor Lebob</a></li>
       </ul>
@@ -161,7 +161,7 @@
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu">
-    <a href="index.html">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
+    <a href="/">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
     <a href="sponsor.html">Sponsors</a><a href="sponsor-how-to.html">Sponsor Lebob</a>
   </div>
 
@@ -233,7 +233,7 @@
     <div class="container footer-inner">
       <div class="footer-left">© 2025 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
-        <li><a href="index.html">Home</a></li><li><a href="media.html">Media</a></li>
+        <li><a href="/">Home</a></li><li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li><li><a href="sponsor.html">Sponsors</a></li>
       </ul>
     </div>

--- a/polish.css
+++ b/polish.css
@@ -1,0 +1,270 @@
+/* =====================================================================
+   polish.css — design-engineering polish layer (Emil Kowalski / animations.dev)
+   ---------------------------------------------------------------------
+   HOW THIS FILE WORKS
+   This stylesheet is <link>ed AFTER each page's inline <style> block, so
+   its rules win ties by source order and INTENTIONALLY OVERRIDE the inline
+   transitions (e.g. the inline `transition: color 0.15s`). Tune timing and
+   easing HERE, not in the per-page <style> blocks — a value you change in a
+   page's <style> may be silently superseded by this file.
+
+   PRINCIPLES APPLIED
+   - Custom easing curves; never `ease-in` on UI; UI durations < 300ms.
+   - Press feedback: scale(~0.97) on :active for every pressable element.
+   - Animate transform / opacity / translate only (GPU); never layout props.
+   - Hover effects gated behind (hover: hover) and (pointer: fine).
+   - Full prefers-reduced-motion support: keep opacity, drop movement.
+   - Enter animations never start from scale(0); ease-out; modals stay centered.
+
+   REVEAL ARCHITECTURE (works with polish.js)
+   - Above the fold (hero / page header): pure-CSS keyframe load animation,
+     gated by `prefers-reduced-motion: no-preference`. No JS, no flash.
+   - Below the fold (card groups / section titles): hidden only when
+     <html> has `.js-reveal` (added by polish.js). If polish.js fails to
+     load, the class is never added and everything stays visible.
+   ===================================================================== */
+
+:root {
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);      /* strong ease-out for UI */
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);  /* on-screen movement */
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);   /* iOS-like drawer curve */
+}
+
+/* ───────────────────────── Links (color hovers) ───────────────────────
+   :not(.nav-cta) so this (more specific) rule doesn't strip the CTA's own
+   transform transition — the CTA is an <a> living inside .nav-links. */
+.nav-links a:not(.nav-cta),
+.footer-links a,
+.mobile-menu a { transition: color 120ms ease; }
+
+/* ───────────────────────── Pressable buttons ──────────────────────── */
+/* Buttons must feel responsive: instant scale-down on press. */
+/* .nav-links a.nav-cta beats the inline `.nav-links a { transition: color }`
+   (0,1,1) which would otherwise strip the CTA's transform transition. */
+.nav-links a.nav-cta,
+.nav-cta {
+  transition: opacity 140ms ease, color 140ms ease, transform 160ms var(--ease-out);
+}
+.nav-cta:active { transform: scale(0.97); }
+
+.cta-btn {
+  transition: opacity 140ms ease, color 140ms ease, transform 160ms var(--ease-out);
+}
+.cta-btn:active { transform: scale(0.97); }
+
+.contact-email {
+  transition: background-color 140ms ease, color 140ms ease, transform 160ms var(--ease-out);
+}
+.contact-email:active { transform: scale(0.97); }
+
+.doc-ext-link {
+  transition: border-color 140ms ease, background-color 140ms ease,
+              color 140ms ease, transform 160ms var(--ease-out);
+}
+.doc-ext-link:active { transform: scale(0.97); }
+
+.nav-hamburger { transition: transform 160ms var(--ease-out); }
+.nav-hamburger:active { transform: scale(0.9); }
+
+/* Lightbox controls (lightbox-nav keeps its translateY centring) */
+.lightbox-close { transition: opacity 140ms ease, transform 160ms var(--ease-out); }
+.lightbox-close:active { transform: scale(0.9); }
+.lightbox-nav { transition: opacity 140ms ease, transform 160ms var(--ease-out); }
+.lightbox-nav:active { transform: translateY(-50%) scale(0.9); }
+
+/* Search input focus */
+.search-bar input { transition: border-color 140ms ease; }
+
+/* ───────────────────────── Cards ──────────────────────────────────────
+   One transition list per card so reveal (opacity + translate, slow) and
+   interaction (transform + colour, fast) never fight over the `transition`
+   shorthand. Reveal uses the independent `translate` property; hover/press
+   use `transform` — so they compose instead of clobbering each other. */
+.highlight-card,
+.project-card,
+.tier-card,
+.where-card,
+.doc-item,
+.sponsor-card,
+.masonry-item,
+.crew-card,
+.section-title,
+.section-label {
+  transition:
+    opacity 500ms var(--ease-out),
+    translate 500ms var(--ease-out),
+    transform 200ms var(--ease-out),
+    border-color 200ms var(--ease-out),
+    background-color 200ms var(--ease-out);
+}
+
+.crew-photo {
+  transition: border-color 200ms var(--ease-out), transform 200ms var(--ease-out);
+}
+
+/* Project-link arrow: nudge with transform instead of animating `gap`
+   (layout property, and a no-op on a single text node anyway). */
+.project-card .project-link { transition: transform 200ms var(--ease-out); }
+
+/* Masonry image zoom — neutralise the inline ungated hover first, then
+   re-enable only on real pointers (so a tap doesn't leave it stuck). */
+.masonry-item img { transition: transform 250ms var(--ease-out); }
+.masonry-item:hover img { transform: none; }
+
+/* ───────────────────────── Hover effects (gated) ──────────────────── */
+@media (hover: hover) and (pointer: fine) {
+  .highlight-card:hover,
+  .project-card:hover,
+  .tier-card:hover,
+  .where-card:hover,
+  .doc-item:hover,
+  .sponsor-card:hover { transform: translateY(-3px); }
+
+  .crew-card:hover .crew-photo { transform: scale(1.04); }
+  .project-card:hover .project-link { transform: translateX(3px); }
+  .masonry-item:hover img { transform: scale(1.03); }
+}
+
+/* ───────────────────────── Press feedback (cards) ─────────────────────
+   Outside the hover query so touch taps get feedback too. After :hover in
+   source order so a press overrides the hover lift while held. */
+.highlight-card:active,
+.project-card:active,
+.tier-card:active,
+.where-card:active,
+.doc-item:active,
+.sponsor-card:active { transform: scale(0.98); }
+.masonry-item:active { transform: scale(0.985); }
+
+/* ───────────────────────── Mobile menu (drawer) ───────────────────────
+   Was a bare display toggle; animate it. Degrades to display:flex if this
+   file is absent. */
+.mobile-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  pointer-events: none;
+  transition: opacity 200ms var(--ease-out),
+              transform 200ms var(--ease-out),
+              visibility 200ms linear;
+}
+.mobile-menu.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+/* ───────────────────────── Lightbox (modal) ───────────────────────────
+   Backdrop fades; image scales in from 0.96 (never from 0). Modal stays
+   centred (default transform-origin) — it isn't anchored to a trigger. */
+.lightbox {
+  display: flex;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 200ms var(--ease-out), visibility 200ms linear;
+}
+.lightbox.open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+.lightbox img {
+  transform: scale(0.96);
+  transition: transform 250ms var(--ease-out);
+}
+.lightbox.open img { transform: scale(1); }
+
+/* ───────────────────────── Above-the-fold load animation ──────────────
+   Pure CSS: renders hidden, rises in. `both` fill holds the start state
+   during the delay, so there is no flash. Gated so reduced motion skips
+   it entirely (content just renders normally). */
+@media (prefers-reduced-motion: no-preference) {
+  .hero-logo,
+  .hero h1,
+  .hero-tagline,
+  .hero .hero-meta,
+  .page-label,
+  .page-title,
+  .page-desc {
+    animation: pl-rise-in 500ms var(--ease-out) both;
+  }
+  .hero h1 { animation-delay: 60ms; }
+  .hero-tagline { animation-delay: 120ms; }
+  .hero .hero-meta { animation-delay: 180ms; }
+  .page-title { animation-delay: 60ms; }
+  .page-desc { animation-delay: 120ms; }
+}
+
+@keyframes pl-rise-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ───────────────────────── Below-the-fold scroll reveal ───────────────
+   Hidden only when polish.js has added `.js-reveal`. polish.js adds
+   `.is-visible` as each group/title scrolls into view (with a capped
+   stagger). Reveal animates opacity + translate (independent property),
+   leaving `transform` free for hover/press. */
+@media (prefers-reduced-motion: no-preference) {
+  .js-reveal .highlight-card,
+  .js-reveal .crew-card,
+  .js-reveal .project-card,
+  .js-reveal .tier-card,
+  .js-reveal .where-card,
+  .js-reveal .doc-item,
+  .js-reveal .masonry-item,
+  .js-reveal .sponsor-card,
+  .js-reveal .section-title,
+  .js-reveal .section-label {
+    opacity: 0;
+    translate: 0 14px;
+  }
+  .js-reveal .is-visible {
+    opacity: 1;
+    translate: 0 0;
+  }
+}
+
+/* ───────────────────────── Reduced motion ─────────────────────────────
+   Keep colour / opacity / border feedback; remove movement. (The reveal
+   and load animations above are already gated to no-preference, so under
+   `reduce` all content renders fully visible.) */
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+
+  .mobile-menu,
+  .mobile-menu.open { transform: none !important; }
+
+  .lightbox img,
+  .lightbox.open img { transform: none !important; }
+
+  .highlight-card:hover,
+  .project-card:hover,
+  .tier-card:hover,
+  .where-card:hover,
+  .doc-item:hover,
+  .sponsor-card:hover,
+  .crew-card:hover .crew-photo,
+  .project-card:hover .project-link,
+  .masonry-item:hover img { transform: none !important; }
+
+  .nav-cta:active,
+  .cta-btn:active,
+  .contact-email:active,
+  .doc-ext-link:active,
+  .nav-hamburger:active,
+  .lightbox-close:active,
+  .highlight-card:active,
+  .project-card:active,
+  .tier-card:active,
+  .where-card:active,
+  .doc-item:active,
+  .sponsor-card:active,
+  .masonry-item:active { transform: none !important; }
+  .lightbox-nav:active { transform: translateY(-50%) !important; }
+}

--- a/polish.js
+++ b/polish.js
@@ -1,0 +1,70 @@
+/* polish.js — below-the-fold scroll reveal (pairs with polish.css).
+ *
+ * SAFE DEGRADATION: the very first line adds `.js-reveal` to <html>, which
+ * is what arms the CSS hide rules. If this file fails to load, the class is
+ * never added and all content stays visible. Loaded with `defer`, so by the
+ * time it runs the DOM is parsed and we reveal in-view elements in the same
+ * tick (no flash) and only animate genuinely off-screen ones on scroll.
+ */
+(function () {
+  var root = document.documentElement;
+  root.classList.add('js-reveal');
+
+  var SELECTOR = [
+    '.highlight-card', '.crew-card', '.project-card', '.tier-card',
+    '.where-card', '.doc-item', '.masonry-item', '.sponsor-card',
+    '.section-title', '.section-label'
+  ].join(',');
+
+  function reveal(el) { el.classList.add('is-visible'); }
+
+  function setup() {
+    var targets = document.querySelectorAll(SELECTOR);
+    var reduce = window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    // No motion wanted, or no observer support: show everything immediately.
+    if (reduce || !('IntersectionObserver' in window)) {
+      for (var i = 0; i < targets.length; i++) reveal(targets[i]);
+      return;
+    }
+
+    var vh = window.innerHeight || root.clientHeight;
+
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        var el = entry.target;
+        io.unobserve(el);
+        reveal(el);
+        // Clear the stagger delay once revealed so later hover/press
+        // transitions on this element aren't delayed.
+        el.addEventListener('transitionend', function clear() {
+          el.style.transitionDelay = '';
+          el.removeEventListener('transitionend', clear);
+        });
+      });
+    }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+
+    targets.forEach(function (el) {
+      var rect = el.getBoundingClientRect();
+      // Already in view at load: reveal instantly, same tick → no flash,
+      // no entrance animation for above-the-fold content.
+      if (rect.top < vh && rect.bottom > 0) {
+        reveal(el);
+        return;
+      }
+      // Below the fold: gentle capped cascade within sibling groups.
+      var sibs = el.parentElement ? el.parentElement.children : [el];
+      var idx = Array.prototype.indexOf.call(sibs, el);
+      el.style.transitionDelay = (Math.min(idx, 6) * 50) + 'ms';
+      io.observe(el);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setup);
+  } else {
+    setup();
+  }
+})();

--- a/sponsor-how-to.html
+++ b/sponsor-how-to.html
@@ -143,6 +143,8 @@
     }
     @media (max-width: 480px) { .container { padding: 0 16px; } }
   </style>
+  <link rel="stylesheet" href="polish.css">
+  <script src="polish.js" defer></script>
 </head>
 <body>
   <nav class="nav">

--- a/sponsor-how-to.html
+++ b/sponsor-how-to.html
@@ -149,9 +149,9 @@
 <body>
   <nav class="nav">
     <div class="container nav-inner">
-      <a href="index.html" class="nav-brand"><img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo"><span>Lebob</span></a>
+      <a href="/" class="nav-brand"><img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo"><span>Lebob</span></a>
       <ul class="nav-links">
-        <li><a href="index.html">Home</a></li><li><a href="media.html">Media</a></li>
+        <li><a href="/">Home</a></li><li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li><li><a href="sponsor.html">Sponsors</a></li>
         <li><a href="sponsor-how-to.html" class="nav-cta">Sponsor Lebob</a></li>
       </ul>
@@ -163,7 +163,7 @@
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu">
-    <a href="index.html">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
+    <a href="/">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
     <a href="sponsor.html">Sponsors</a><a href="sponsor-how-to.html">Sponsor Lebob</a>
   </div>
 
@@ -272,7 +272,7 @@
     <div class="container footer-inner">
       <div class="footer-left">© 2025 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
-        <li><a href="index.html">Home</a></li><li><a href="media.html">Media</a></li>
+        <li><a href="/">Home</a></li><li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li><li><a href="sponsor.html">Sponsors</a></li>
       </ul>
     </div>

--- a/sponsor.html
+++ b/sponsor.html
@@ -147,6 +147,8 @@
       .container { padding: 0 16px; }
     }
   </style>
+  <link rel="stylesheet" href="polish.css">
+  <script src="polish.js" defer></script>
 </head>
 <body>
   <nav class="nav">

--- a/sponsor.html
+++ b/sponsor.html
@@ -153,12 +153,12 @@
 <body>
   <nav class="nav">
     <div class="container nav-inner">
-      <a href="index.html" class="nav-brand">
+      <a href="/" class="nav-brand">
         <img src="mp5lqqec-Pixel-but-scaled-lebob.png" alt="Lebob logo">
         <span>Lebob</span>
       </a>
       <ul class="nav-links">
-        <li><a href="index.html">Home</a></li>
+        <li><a href="/">Home</a></li>
         <li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li>
         <li><a href="sponsor.html">Sponsors</a></li>
@@ -172,7 +172,7 @@
     </div>
   </nav>
   <div class="mobile-menu" id="mobileMenu">
-    <a href="index.html">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
+    <a href="/">Home</a><a href="media.html">Media</a><a href="docs.html">Docs</a>
     <a href="sponsor.html">Sponsors</a><a href="sponsor-how-to.html">Sponsor Lebob</a>
   </div>
 
@@ -228,7 +228,7 @@
     <div class="container footer-inner">
       <div class="footer-left">© 2025 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
-        <li><a href="index.html">Home</a></li><li><a href="media.html">Media</a></li>
+        <li><a href="/">Home</a></li><li><a href="media.html">Media</a></li>
         <li><a href="docs.html">Docs</a></li><li><a href="sponsor.html">Sponsors</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## What

Applies Emil Kowalski's design-engineering principles across the whole static site, plus a small clean-URL fix.

All 5 pages share ~80% identical inline CSS, so instead of editing each 5×, the polish lives in a shared **`polish.css`** + **`polish.js`**, linked after each page's inline `<style>` so it overrides the existing transitions by source order. Each page changed by only +2 lines (the `<link>`/`<script>`).

## Changes

**Design polish (`polish.css` / `polish.js`)**
- Custom easing tokens (`--ease-out` / `--ease-in-out` / `--ease-drawer`) — replaces weak browser defaults
- `scale(0.97)` `:active` press feedback on every button / CTA / card-link
- Card hover lifts, crew-photo + masonry zoom, project-link arrow nudge (via `transform`, not animating `gap`)
- Hover effects gated behind `(hover: hover) and (pointer: fine)` so taps don't get stuck states
- Mobile menu + lightbox now animate open/close (were bare `display` toggles); lightbox stays centred as a modal, image scales from `0.96` not `0`
- Pure-CSS rise-in for above-the-fold hero / page headers
- Below-the-fold scroll reveal with capped 50ms stagger; the hide-class is added *by* the JS, so it degrades to fully-visible if the script ever fails to load
- Full `prefers-reduced-motion: reduce` support (keeps opacity/colour, drops movement)

**Clean URL**
- Home / logo links now point at `/` instead of `index.html`, so navigating home shows `lebob.com.au/` rather than `lebob.com.au/index.html`

## Verification

Driven with headless Chromium (puppeteer-core → `/usr/bin/chromium`), not just by reading CSS:
- **All 5 pages: zero stuck-hidden elements** under both `prefers-reduced-motion: reduce` and a normal scroll-through (the key risk for the reveal layer)
- `:active` press scale, nav-CTA/CTA transform transitions, hover/nudge rules (confirmed via CSSOM since headless reports no hover capability), mobile-menu open/close, and lightbox open all render correctly

## Notes / out of scope
- `index.html` tech-stack still lists "Next.js (this site)" — no longer accurate after the static-HTML migration (content fix, not polish)
- The gallery references the multi-MB root `.JPG` originals while optimised `webp` variants sit unused in `public/_img/` — a real perf win, but separate work
