### PR TITLE
feat: add sponsorship tiers and Founding Supporter band

### DIFF
--- a/index.html
+++ b/index.html
@@ -768,9 +768,9 @@
     <div class="container">
       <div class="cta-inner">
         <h2>Sponsor a future builder.</h2>
-        <p>Open to sponsorship, mentorship, and collaboration with other teams. Drop us a line · we run lean and we ship.</p>
+        <p>Four sponsorship tiers from $500 up, plus mentorship and collaboration with other teams. Drop us a line · we run lean and we ship.</p>
         <a href="/sponsors/how-to/" class="cta-btn">
-          Sponsor Lebob
+          See sponsorship tiers
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M3 8h10M9 4l4 4-4 4"/>
           </svg>

--- a/sponsors/how-to/index.html
+++ b/sponsors/how-to/index.html
@@ -62,7 +62,11 @@
     .section-title { font-family: var(--font-display); font-size: clamp(22px, 3vw, 30px); font-weight: 700; line-height: 1.2; color: var(--fg-dark); margin-bottom: 16px; }
 
     .tiers-grid {
-      display: grid; grid-template-columns: repeat(3, 1fr);
+      display: grid; grid-template-columns: repeat(4, 1fr);
+      gap: 16px; margin-top: 32px;
+    }
+    .options-grid {
+      display: grid; grid-template-columns: repeat(2, 1fr);
       gap: 16px; margin-top: 32px;
     }
     .tier-card {
@@ -71,12 +75,17 @@
       display: flex; flex-direction: column;
     }
     .tier-card:hover { border-color: var(--accent-bright); }
+    .tier-card--gold { border-color: var(--accent); background: var(--surface); }
     .tier-num {
       font-family: var(--font-mono); font-size: 13px; font-weight: 500;
       color: var(--accent); margin-bottom: 12px;
     }
     .tier-card h3 {
-      font-size: 20px; font-weight: 700; color: var(--fg-dark); margin-bottom: 8px;
+      font-size: 20px; font-weight: 700; color: var(--fg-dark); margin-bottom: 4px;
+    }
+    .tier-price {
+      font-family: var(--font-mono); font-size: 15px; font-weight: 500;
+      color: var(--fg-dark); margin-bottom: 10px;
     }
     .tier-card p { font-size: 15px; line-height: 1.6; color: var(--muted); flex: 1; }
     .tier-examples {
@@ -133,10 +142,14 @@
     .footer-links a { font-size: 14px; color: var(--muted); transition: color 0.15s; }
     .footer-links a:hover { color: var(--accent); }
 
+    @media (max-width: 1024px) {
+      .tiers-grid { grid-template-columns: repeat(2, 1fr); }
+    }
     @media (max-width: 768px) {
       .nav-links { display: none; }
       .nav-hamburger { display: block; }
       .tiers-grid { grid-template-columns: 1fr; }
+      .options-grid { grid-template-columns: 1fr; }
       .where-grid { grid-template-columns: 1fr; }
       .footer-inner { flex-direction: column; text-align: center; }
       .footer-links { justify-content: center; }
@@ -172,30 +185,78 @@
     <div class="container">
       <div class="page-label">Sponsorships · how to help</div>
       <h1 class="page-title">How to sponsor us.</h1>
-      <p class="page-desc">Your support helps the team build better robots, travel to competitions, and share STEM with more students. We welcome sponsors of every size.</p>
+      <p class="page-desc">Your support helps the team build better robots, travel to competitions, and share STEM with more students. Four tiers, from $500 to season naming rights &mdash; plus equipment and mentorship, which count just as much.</p>
     </div>
   </header>
 
   <!-- TIERS -->
   <section class="section">
     <div class="container">
-      <div class="section-label">01 · how you can help / ~/options</div>
-      <h2 class="section-title">Sponsorship options</h2>
+      <div class="section-label">01 · sponsorship tiers / ~/levels</div>
+      <h2 class="section-title">Sponsorship tiers</h2>
+      <p class="page-desc">Each tier includes everything in the tiers below it. Amounts are a starting point, not a ceiling — if you want to build something different, talk to us.</p>
       <div class="tiers-grid">
         <div class="tier-card">
-          <div class="tier-num">01</div>
-          <h3>Financial Sponsorship</h3>
-          <p>Sponsor travel, registration fees, and build materials for the season.</p>
+          <div class="tier-num">01 · Bronze</div>
+          <h3>Bronze</h3>
+          <div class="tier-price">from $500</div>
+          <p>Get your name in front of the team, the competition, and the community.</p>
           <ul class="tier-examples">
-            <li>International travel (Korea Open)</li>
-            <li>FLL registration fees</li>
-            <li>3D printing materials</li>
-            <li>Sensor & electronics parts</li>
+            <li>Logo &amp; link on lebob.com.au</li>
+            <li>Logo on our pit display</li>
+            <li>Thank-you post on our socials</li>
+            <li>End-of-season report</li>
           </ul>
         </div>
         <div class="tier-card">
-          <div class="tier-num">02</div>
-          <h3>Equipment & Materials</h3>
+          <div class="tier-num">02 · Silver</div>
+          <h3>Silver</h3>
+          <div class="tier-price">from $1,500</div>
+          <p>Everything in Bronze, plus a place on the kit we wear all season.</p>
+          <ul class="tier-examples">
+            <li>Logo on the season team shirt</li>
+            <li>Named in judging presentations</li>
+            <li>Named at outreach events</li>
+            <li>A dedicated post about the partnership</li>
+          </ul>
+        </div>
+        <div class="tier-card tier-card--gold">
+          <div class="tier-num">03 · Gold</div>
+          <h3>Gold</h3>
+          <div class="tier-price">from $3,000</div>
+          <p>Everything in Silver, plus prime placement and time with the team.</p>
+          <ul class="tier-examples">
+            <li>Prominent shirt placement</li>
+            <li>Logo on the robot, where the rules allow</li>
+            <li>A team demo at your workplace</li>
+            <li>Featured writeup &amp; outreach materials</li>
+          </ul>
+        </div>
+        <div class="tier-card">
+          <div class="tier-num">04 · Platinum</div>
+          <h3>Platinum</h3>
+          <div class="tier-price">from $5,000 · tailored</div>
+          <p>Everything in Gold, built around what your organisation actually wants.</p>
+          <ul class="tier-examples">
+            <li>Season or robot naming rights</li>
+            <li>Top billing across everything we make</li>
+            <li>Student site visits &amp; careers sessions</li>
+            <li>Shaped with you, not off a list</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- IN-KIND -->
+  <section class="section section-border">
+    <div class="container">
+      <div class="section-label">02 · in-kind / ~/other-ways</div>
+      <h2 class="section-title">Not everything useful is cash</h2>
+      <p class="page-desc">Equipment, materials and expertise are worth just as much to us. In-kind support is recognised the same way — we'll place you at the tier that matches what you've given.</p>
+      <div class="options-grid">
+        <div class="tier-card">
+          <div class="tier-num">Equipment &amp; materials</div>
           <p>Tools, fabrication help, prototyping supplies, or printing resources.</p>
           <ul class="tier-examples">
             <li>LEGO Spike Prime kits</li>
@@ -205,13 +266,12 @@
           </ul>
         </div>
         <div class="tier-card">
-          <div class="tier-num">03</div>
-          <h3>Professional Support</h3>
+          <div class="tier-num">Professional support</div>
           <p>Volunteer mentorship in engineering, software, comms, or planning.</p>
           <ul class="tier-examples">
             <li>Robotics engineering</li>
             <li>Soft robotics research</li>
-            <li>CAD & manufacturing</li>
+            <li>CAD &amp; manufacturing</li>
             <li>Presentation coaching</li>
           </ul>
         </div>
@@ -222,7 +282,7 @@
   <!-- WHERE MONEY GOES -->
   <section class="section section-border">
     <div class="container">
-      <div class="section-label">02 · impact / where it goes</div>
+      <div class="section-label">03 · impact / where it goes</div>
       <h2 class="section-title">Where your support goes</h2>
       <div class="where-grid">
         <div class="where-card">
@@ -248,12 +308,13 @@
   <!-- WHAT SPONSORS GET -->
   <section class="section section-border">
     <div class="container">
-      <div class="section-label">What you get</div>
-      <h2 class="section-title">What sponsors receive</h2>
+      <div class="section-label">04 · the details / ~/fine-print</div>
+      <h2 class="section-title">The details</h2>
       <ul class="benefits-list">
-        <li>Recognition on team materials and sponsorship page</li>
-        <li>Highlight mentions in team presentations and outreach</li>
-        <li>A direct role in supporting student engineering growth</li>
+        <li>All amounts are in AUD and exclude GST. Every sponsorship is invoiced, so it goes through your books as a marketing expense rather than a donation.</li>
+        <li>Shirt logos have to be locked in before the season print run. Ask us for this season's cutoff date before you commit to a Silver tier or above.</li>
+        <li>Logo placement on the robot is subject to the competition's branding rules, which set limits on size and position.</li>
+        <li>Tiers apply from the 2026&ndash;27 season onward. The organisations who backed us before we had a tier structure are listed permanently as <a href="/sponsors/" style="color:var(--accent)">Founding Supporters</a>.</li>
       </ul>
     </div>
   </section>
@@ -263,7 +324,7 @@
     <div class="container">
       <div class="contact-box">
         <h3>Sponsor Lebob this season.</h3>
-        <p>Reach out and we will share sponsor levels, timelines, and how your support will be acknowledged.</p>
+        <p>Pick a tier, or tell us what you had in mind. We'll come back with an invoice, the season timeline, and exactly how you'll be acknowledged.</p>
         <a href="mailto:team@lebob.com.au" class="contact-email">team@lebob.com.au</a>
       </div>
     </div>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -183,12 +183,13 @@
       <div class="page-label">Sponsors · Team #3236</div>
       <h1 class="page-title">Thanks to the people who back us.</h1>
       <p class="page-desc">We appreciate the organizations that support Team Lebob and help us keep building, learning, and competing.</p>
+      <p class="page-desc" style="margin-top:16px;">Every organisation below backed us before we had a sponsorship structure at all &mdash; on a handshake and a walk-in. They keep the Founding Supporter badge permanently. <a href="/sponsors/how-to/" style="color:var(--accent)">Sponsorship tiers</a> apply from the 2026&ndash;27 season onward.</p>
     </div>
   </header>
 
   <section class="sponsor-featured">
     <div class="container">
-      <div class="section-label" style="font-family:var(--font-mono);font-size:13px;font-weight:500;text-transform:uppercase;letter-spacing:0.05em;color:var(--accent);margin-bottom:16px;">01 · current sponsors / ~/partners</div>
+      <div class="section-label" style="font-family:var(--font-mono);font-size:13px;font-weight:500;text-transform:uppercase;letter-spacing:0.05em;color:var(--accent);margin-bottom:16px;">01 · founding supporters / ~/partners</div>
       <div class="sponsor-card">
         <div class="sponsor-logo">
           <a href="https://warobotics.education/" target="_blank" rel="noopener">
@@ -196,7 +197,7 @@
           </a>
         </div>
         <div class="sponsor-info">
-          <span class="sponsor-tag">01 · Featured</span>
+          <span class="sponsor-tag">01 · Founding Supporter</span>
           <h3>WA Robotics Education</h3>
           <p>WARES · Long-time backers of Western Australian robotics teams. Click the logo to visit their site.</p>
         </div>
@@ -209,7 +210,7 @@
           </a>
         </div>
         <div class="sponsor-info">
-          <span class="sponsor-tag">02 · Sponsor</span>
+          <span class="sponsor-tag">02 · Founding Supporter</span>
           <h3>Fugro</h3>
           <p>Fugro · Global leader in geo-data and asset integrity solutions for marine, energy, and infrastructure sectors.</p>
         </div>
@@ -222,7 +223,7 @@
           </a>
         </div>
         <div class="sponsor-info">
-          <span class="sponsor-tag">03 · Sponsor</span>
+          <span class="sponsor-tag">03 · Founding Supporter</span>
           <h3>Pulse Technology Hub</h3>
           <p>Pulse · Perth-based hub showcasing global industrial technology and connecting operators with new subsea and energy innovation.</p>
         </div>
@@ -235,7 +236,7 @@
           </a>
         </div>
         <div class="sponsor-info">
-          <span class="sponsor-tag">04 · Sponsor</span>
+          <span class="sponsor-tag">04 · Founding Supporter</span>
           <h3>EFFEE Robotics</h3>
           <p>Effee OSR · On-site and subsea robotic welding for in-service pipeline and asset repair.</p>
         </div>
@@ -248,7 +249,7 @@
           </a>
         </div>
         <div class="sponsor-info">
-          <span class="sponsor-tag">05 · Sponsor</span>
+          <span class="sponsor-tag">05 · Founding Supporter</span>
           <h3>CP Maritime</h3>
           <p>CP Maritime · Perth marine-technology partner supplying advanced subsea and vessel systems.</p>
         </div>
@@ -261,7 +262,7 @@
           </a>
         </div>
         <div class="sponsor-info">
-          <span class="sponsor-tag">06 · Sponsor</span>
+          <span class="sponsor-tag">06 · Founding Supporter</span>
           <h3>TMT Solves</h3>
           <p>TMT · Australian-made ROVs and subsea tooling, engineered in WA for harsh offshore environments.</p>
         </div>
@@ -273,9 +274,9 @@
     <div class="container">
       <div class="invite-box">
         <h2>Sponsor a future builder.</h2>
-        <p>Open to financial support, equipment, mentorship · or all three. Every level helps the workshop tick over.</p>
+        <p>Four tiers from $500 up, plus equipment and mentorship &mdash; which count just as much. Every level helps the workshop tick over.</p>
         <a href="/sponsors/how-to/" class="cta-btn">
-          Read how to sponsor
+          See sponsorship tiers
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
         </a>
       </div>


### PR DESCRIPTION
## What

Adds a real sponsorship ladder to `/sponsors/how-to/` and reframes the existing sponsor wall on `/sponsors/`.

**Four tiers, priced as floors:**

| Tier | From | Headline benefit |
|---|---|---|
| Bronze | $500 | Website + pit display, thank-you post |
| Silver | $1,500 | Logo on the season shirt, named in judging |
| Gold | $3,000 | Prominent shirt + robot placement, workplace demo |
| Platinum | $5,000 | Season/robot naming, tailored |

Every price reads "from $X" rather than a fixed figure. A published fixed number anchors walk-in conversations *down* — and walk-ins are what actually convert for this team.

**In-kind gets its own lane.** Equipment and mentorship moved out of the cash ladder so they stop competing with it.

**Details section** added: GST/invoicing, the shirt print cutoff, and the note that robot logo placement is bounded by competition branding rules.

## Founding Supporters

The six existing sponsors are badged **Founding Supporters** rather than assigned tiers. They committed before any tier structure existed, so retroactively tiering them would have capped renewals (our top prior gift sits above the old proposed ceiling) and misrepresented what was actually given. The badge is permanent and closed to new entrants; tiers apply from the 2026–27 season onward.

## Verification

HTML structure validated on all three changed pages (tag balance, no unclosed elements). Tier grid is responsive: 4 columns → 2 at ≤1024px → 1 at ≤768px.

## Follow-ups (not in this PR)

- Shirt cutoff date is described but not stated — needs a real date once the print run is booked.
- Worth producing the same content as a hand-over one-pager for walk-ins.