### PR TITLE
fix: lay out founding supporters two-up and trim in-kind list

### DIFF
--- a/sponsors/how-to/index.html
+++ b/sponsors/how-to/index.html
@@ -259,7 +259,6 @@
           <div class="tier-num">Equipment &amp; materials</div>
           <p>Tools, fabrication help, prototyping supplies, or printing resources.</p>
           <ul class="tier-examples">
-            <li>LEGO Spike Prime kits</li>
             <li>3D printer filament</li>
             <li>Electronics components</li>
             <li>Workshop supplies</li>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -78,16 +78,20 @@
     .sponsor-featured {
       padding: clamp(48px, 6vw, 80px) 0;
     }
+    .sponsors-grid {
+      display: grid; grid-template-columns: repeat(2, 1fr);
+      gap: 20px; margin-top: 32px;
+    }
     .sponsor-card {
-      display: flex; align-items: center; gap: clamp(24px, 4vw, 48px);
-      padding: clamp(24px, 4vw, 40px);
+      display: flex; align-items: center; gap: 24px;
+      padding: 24px; height: 100%;
       border: 1px solid var(--border); border-radius: var(--radius-md);
       background: var(--bg);
     }
     .sponsor-logo {
       flex-shrink: 0;
-      width: clamp(140px, 20vw, 220px);
-      padding: 16px;
+      width: clamp(96px, 11vw, 132px);
+      padding: 12px;
       background: #2a2b30;
       border: 1px solid var(--border);
       border-radius: var(--radius);
@@ -95,10 +99,10 @@
     .sponsor-logo img { width: 100%; height: auto; }
     .sponsor-logo--light { background: #ffffff; border-color: #e5e6e0; }
     .sponsor-info h3 {
-      font-size: clamp(20px, 2.5vw, 24px); font-weight: 700;
-      color: var(--fg-dark); margin-bottom: 8px;
+      font-size: 19px; font-weight: 700;
+      color: var(--fg-dark); margin-bottom: 6px;
     }
-    .sponsor-info p { font-size: 16px; line-height: 1.6; color: var(--muted); }
+    .sponsor-info p { font-size: 14px; line-height: 1.55; color: var(--muted); }
     .sponsor-info .sponsor-tag {
       display: inline-block; font-family: var(--font-mono); font-size: 12px;
       font-weight: 500; color: var(--accent); background: var(--accent-light);
@@ -136,11 +140,14 @@
     .footer-links a { font-size: 14px; color: var(--muted); transition: color 0.15s; }
     .footer-links a:hover { color: var(--accent); }
 
+    @media (max-width: 900px) {
+      .sponsors-grid { grid-template-columns: 1fr; }
+    }
     @media (max-width: 768px) {
       .nav-links { display: none; }
       .nav-hamburger { display: block; }
       .sponsor-card { flex-direction: column; text-align: center; }
-      .sponsor-logo { width: 180px; margin: 0 auto; }
+      .sponsor-logo { width: 150px; margin: 0 auto; }
       .footer-inner { flex-direction: column; text-align: center; }
       .footer-links { justify-content: center; }
     }
@@ -190,6 +197,7 @@
   <section class="sponsor-featured">
     <div class="container">
       <div class="section-label" style="font-family:var(--font-mono);font-size:13px;font-weight:500;text-transform:uppercase;letter-spacing:0.05em;color:var(--accent);margin-bottom:16px;">01 · founding supporters / ~/partners</div>
+      <div class="sponsors-grid">
       <div class="sponsor-card">
         <div class="sponsor-logo">
           <a href="https://warobotics.education/" target="_blank" rel="noopener">
@@ -203,7 +211,7 @@
         </div>
       </div>
 
-      <div class="sponsor-card" style="margin-top: 24px;">
+      <div class="sponsor-card">
         <div class="sponsor-logo">
           <a href="https://www.fugro.com/" target="_blank" rel="noopener">
             <img src="/img/fugro-logo.webp" alt="Fugro logo" style="filter: invert(1);">
@@ -216,10 +224,10 @@
         </div>
       </div>
 
-      <div class="sponsor-card" style="margin-top: 24px;">
+      <div class="sponsor-card">
         <div class="sponsor-logo sponsor-logo--light">
           <a href="https://pulsetechnologyhub.com.au/" target="_blank" rel="noopener">
-            <img src="/img/pulse-logo.webp" alt="Pulse Technology Hub logo" style="max-height:160px;width:auto;margin:0 auto;">
+            <img src="/img/pulse-logo.webp" alt="Pulse Technology Hub logo" style="max-height:96px;width:auto;max-width:100%;margin:0 auto;">
           </a>
         </div>
         <div class="sponsor-info">
@@ -229,7 +237,7 @@
         </div>
       </div>
 
-      <div class="sponsor-card" style="margin-top: 24px;">
+      <div class="sponsor-card">
         <div class="sponsor-logo">
           <a href="https://www.effee-osr.com/" target="_blank" rel="noopener">
             <img src="/img/effee-logo.svg" alt="Effee On Site Robotics logo">
@@ -242,7 +250,7 @@
         </div>
       </div>
 
-      <div class="sponsor-card" style="margin-top: 24px;">
+      <div class="sponsor-card">
         <div class="sponsor-logo sponsor-logo--light">
           <a href="https://cpmaritime.com/" target="_blank" rel="noopener">
             <img src="/img/cpmaritime-logo.webp" alt="CP Maritime logo">
@@ -255,10 +263,10 @@
         </div>
       </div>
 
-      <div class="sponsor-card" style="margin-top: 24px;">
+      <div class="sponsor-card">
         <div class="sponsor-logo">
           <a href="https://www.tmtrov.com/" target="_blank" rel="noopener">
-            <img src="/img/tmt-logo.svg" alt="TMT Solves (Total Marine Technology) logo" style="max-width:150px;margin:0 auto;">
+            <img src="/img/tmt-logo.svg" alt="TMT Solves (Total Marine Technology) logo" style="max-width:100%;margin:0 auto;">
           </a>
         </div>
         <div class="sponsor-info">
@@ -266,6 +274,7 @@
           <h3>TMT Solves</h3>
           <p>TMT · Australian-made ROVs and subsea tooling, engineered in WA for harsh offshore environments.</p>
         </div>
+      </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Follow-up to #56.

## Founding Supporter cards were too big

Six full-width rows stacked vertically made `/sponsors/` very long, with a lot of dead space to the right of each logo. Now a two-column grid:

- New `.sponsors-grid` wrapper, `repeat(2, 1fr)`, 20px gap
- Logo chip `clamp(140px, 20vw, 220px)` → `clamp(96px, 11vw, 132px)`
- Card padding `clamp(24px, 4vw, 40px)` → flat `24px`; `height: 100%` so paired cards match
- Heading `clamp(20px, 2.5vw, 24px)` → `19px`, body `16px` → `14px`
- Inline `margin-top: 24px` removed from five cards (grid gap handles spacing)

**Responsive:** 2 columns → 1 at ≤900px. The existing ≤768px rule still stacks each card centred; its logo override dropped `180px` → `150px` so it isn't larger than the desktop chip.

**Overflow fix:** the Pulse and TMT logos carry inline sizing that overrides `.sponsor-logo img { width: 100% }`. Pulse's `width:auto` with no max-width would have overflowed the smaller chip — both now capped at `max-width: 100%`.

## Also

Dropped "LEGO Spike Prime kits" from the in-kind equipment list on `/sponsors/how-to/`.

## Verification

HTML tag-balance validated on both changed pages. No headless browser on this machine, so the layout is reasoned from the numbers rather than screenshotted: at a 1200px viewport each card is ~566px wide, leaving ~362px of text column after the logo, gap and padding — comfortable. At the 900px breakpoint it's ~245px, which is the tightest it gets before collapsing to one column.