### PR TITLE
feat: present Lebob as both an FLL and FTC team

### DIFF
--- a/docs/fll-2025-2026/index.html
+++ b/docs/fll-2025-2026/index.html
@@ -340,7 +340,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Lebob — FLL Team #3236</title>
+  <title>Lebob — FLL &amp; FTC Robotics Team</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -559,7 +559,7 @@
       <h1>LEBOB</h1>
       <p class="hero-tagline">Robots that compete. <em>Ideas that inspire.</em></p>
       <div class="hero-meta">
-        <span>FLL Team #3236</span>
+        <span>FLL &amp; FTC Team</span>
         <span class="dot"></span>
         <span>Perth, Western Australia</span>
       </div>
@@ -654,7 +654,7 @@
       <div class="section-label">02 · about / whoami</div>
       <h2 class="section-title">Who we are</h2>
       <div class="about-text">
-        <p><strong>Lebob is an international FIRST LEGO League team based in Perth, Western Australia.</strong> We engineer robots, research soft-robotic mechanisms, and ship our work as documentation others can learn from.</p>
+        <p><strong>Lebob is an international FIRST LEGO League and FIRST Tech Challenge team based in Perth, Western Australia.</strong> We engineer robots, research soft-robotic mechanisms, and ship our work as documentation others can learn from.</p>
         <br>
         <p>Eight members, two mentors, one shared workshop. Our goal is turning ideas into real, working prototypes through teamwork, and then sharing them with the rest of the engineering world.</p>
         <br>
@@ -783,7 +783,7 @@
   <footer class="footer">
     <div class="container footer-inner">
       <div class="footer-left">
-        © 2025–2026 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a>
+        © 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a>
       </div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li>
@@ -799,7 +799,7 @@
       'robots that compete.',
       'ideas that inspire.',
       'perth, western australia.',
-      'first lego league #3236.',
+      'first lego league + tech challenge.',
       'season: unearthed.'
     ];
     let tagIdx = 0;

--- a/media/index.html
+++ b/media/index.html
@@ -232,7 +232,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/sponsors/how-to/index.html
+++ b/sponsors/how-to/index.html
@@ -185,7 +185,7 @@
     <div class="container">
       <div class="page-label">Sponsorships · how to help</div>
       <h1 class="page-title">How to sponsor us.</h1>
-      <p class="page-desc">Your support helps the team build better robots, travel to competitions, and share STEM with more students. Four tiers, from $500 to season naming rights &mdash; plus equipment and mentorship, which count just as much.</p>
+      <p class="page-desc">Your support helps the team build better robots, travel to competitions, and share STEM with more students. Four tiers, from $500 up to season naming rights. Equipment and mentorship count just as much.</p>
     </div>
   </header>
 
@@ -194,7 +194,7 @@
     <div class="container">
       <div class="section-label">01 · sponsorship tiers / ~/levels</div>
       <h2 class="section-title">Sponsorship tiers</h2>
-      <p class="page-desc">Each tier includes everything in the tiers below it. Amounts are a starting point, not a ceiling — if you want to build something different, talk to us.</p>
+      <p class="page-desc">Each tier includes everything in the tiers below it. Amounts are a starting point, not a ceiling. If you want to build something different, talk to us.</p>
       <div class="tiers-grid">
         <div class="tier-card">
           <div class="tier-num">01 · Bronze</div>
@@ -253,7 +253,7 @@
     <div class="container">
       <div class="section-label">02 · in-kind / ~/other-ways</div>
       <h2 class="section-title">Not everything useful is cash</h2>
-      <p class="page-desc">Equipment, materials and expertise are worth just as much to us. In-kind support is recognised the same way — we'll place you at the tier that matches what you've given.</p>
+      <p class="page-desc">Equipment, materials and expertise are worth just as much to us. In-kind support is recognised the same way: we'll place you at the tier that matches what you've given.</p>
       <div class="options-grid">
         <div class="tier-card">
           <div class="tier-num">Equipment &amp; materials</div>
@@ -331,7 +331,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -187,10 +187,10 @@
 
   <header class="page-header">
     <div class="container">
-      <div class="page-label">Sponsors · Team #3236</div>
+      <div class="page-label">Sponsors · Team Lebob</div>
       <h1 class="page-title">Thanks to the people who back us.</h1>
       <p class="page-desc">We appreciate the organizations that support Team Lebob and help us keep building, learning, and competing.</p>
-      <p class="page-desc" style="margin-top:16px;">Every organisation below backed us before we had a sponsorship structure at all &mdash; on a handshake and a walk-in. They keep the Founding Supporter badge permanently. <a href="/sponsors/how-to/" style="color:var(--accent)">Sponsorship tiers</a> apply from the 2026&ndash;27 season onward.</p>
+      <p class="page-desc" style="margin-top:16px;">Every organisation below backed us before we had a sponsorship structure at all, on a handshake and a walk-in. They keep the Founding Supporter badge permanently. <a href="/sponsors/how-to/" style="color:var(--accent)">Sponsorship tiers</a> apply from the 2026&ndash;27 season onward.</p>
     </div>
   </header>
 
@@ -283,7 +283,7 @@
     <div class="container">
       <div class="invite-box">
         <h2>Sponsor a future builder.</h2>
-        <p>Four tiers from $500 up, plus equipment and mentorship &mdash; which count just as much. Every level helps the workshop tick over.</p>
+        <p>Four tiers from $500 up, plus equipment and mentorship, which count just as much. Every level helps the workshop tick over.</p>
         <a href="/sponsors/how-to/" class="cta-btn">
           See sponsorship tiers
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8h10M9 4l4 4-4 4"/></svg>
@@ -294,7 +294,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL Team #3236 · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>


### PR DESCRIPTION
## Dual-program identity

The team now competes in FIRST Tech Challenge as well as FIRST LEGO League, so the site shouldn't describe itself as FLL-only.

**The team number is removed rather than updated.** `#3236` is the FLL number; FTC issues a separate one. Carrying either alone implies a single affiliation, which is now wrong.

| Where | Before | After |
|---|---|---|
| `<title>` | Lebob — FLL Team #3236 | Lebob — FLL & FTC Robotics Team |
| Hero meta | FLL Team #3236 | FLL & FTC Team |
| About para | "an international FIRST LEGO League team" | "…FIRST LEGO League and FIRST Tech Challenge team" |
| Hero tagline | `first lego league #3236.` | `first lego league + tech challenge.` |
| Sponsors label | Sponsors · Team #3236 | Sponsors · Team Lebob |
| Footer (×6 pages) | Lebob — FLL Team #3236 | Lebob — FLL & FTC Robotics Team |

### Deliberately not changed

References tied to a specific FLL season or artefact are accurate history, not identity claims:

- "FLL Unearthed Robot" project card
- The `FLL-Lebob-Unearthed` repo link (literal repo name)
- The `FLL 2025–2026` docs season section and its page
- "Won national + state competitions in First Lego League"

Those all still describe FLL work that really was FLL work. Rewriting them would make the history wrong.

## Em dashes

Removed from the sponsorship copy added this week, on all five occurrences. Each sentence was **rewritten** rather than having the dash swapped for another separator:

- "…naming rights — plus equipment and mentorship, which count just as much" → "…up to season naming rights. Equipment and mentorship count just as much."
- "…not a ceiling — if you want to build…" → "…not a ceiling. If you want to build…"
- "…the same way — we'll place you…" → "…the same way: we'll place you…"
- "…structure at all — on a handshake…" → "…structure at all, on a handshake…"
- "…and mentorship — which count just as much" → "…and mentorship, which count just as much"

Left in place: em dashes in page `<title>` tags and the `.tier-examples` bullet glyph. Those are the site's existing separator style, not prose.

## Verification

Tag-balance validated on all six pages. `grep` confirms zero remaining `3236` occurrences and zero em dashes in sponsor prose.