### PR TITLE
Add ABN and address to site footer

### DIFF
--- a/docs/fll-2025-2026/index.html
+++ b/docs/fll-2025-2026/index.html
@@ -340,7 +340,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/docs/fll-2025-2026/index.html
+++ b/docs/fll-2025-2026/index.html
@@ -340,7 +340,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br><a href="https://abr.business.gov.au/ABN/View?abn=41535175584" target="_blank" rel="noopener">ABN 41 535 175 584</a> · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br><a href="https://abr.business.gov.au/ABN/View?abn=41535175584" target="_blank" rel="noopener">ABN 41 535 175 584</a> · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/index.html
+++ b/index.html
@@ -783,7 +783,8 @@
   <footer class="footer">
     <div class="container footer-inner">
       <div class="footer-left">
-        © 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a>
+        © 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>
+        ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA
       </div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li>

--- a/index.html
+++ b/index.html
@@ -784,7 +784,7 @@
     <div class="container footer-inner">
       <div class="footer-left">
         © 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>
-        ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA
+        <a href="https://abr.business.gov.au/ABN/View?abn=41535175584" target="_blank" rel="noopener">ABN 41 535 175 584</a> · 93 Beauchamp Loop, Perth WA
       </div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li>

--- a/media/index.html
+++ b/media/index.html
@@ -232,7 +232,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/media/index.html
+++ b/media/index.html
@@ -232,7 +232,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br><a href="https://abr.business.gov.au/ABN/View?abn=41535175584" target="_blank" rel="noopener">ABN 41 535 175 584</a> · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/sponsors/how-to/index.html
+++ b/sponsors/how-to/index.html
@@ -331,7 +331,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/sponsors/how-to/index.html
+++ b/sponsors/how-to/index.html
@@ -331,7 +331,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br><a href="https://abr.business.gov.au/ABN/View?abn=41535175584" target="_blank" rel="noopener">ABN 41 535 175 584</a> · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -294,7 +294,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br><a href="https://abr.business.gov.au/ABN/View?abn=41535175584" target="_blank" rel="noopener">ABN 41 535 175 584</a> · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -294,7 +294,7 @@
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a></div>
+      <div class="footer-left">© 2025–2026 Lebob — FLL &amp; FTC Robotics Team · <a href="mailto:team@lebob.com.au">team@lebob.com.au</a><br>ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA</div>
       <ul class="footer-links">
         <li><a href="/">Home</a></li><li><a href="/media/">Media</a></li>
         <li><a href="/docs/">Docs</a></li><li><a href="/sponsors/">Sponsors</a></li>


### PR DESCRIPTION
Adds the Lebob Robotics ABN and street address to the site footer, both of which are required for the Google Workspace for Nonprofits application.

## Changes

Added two lines to the footer on all six pages:

```
ABN 41 535 175 584 · 93 Beauchamp Loop, Perth WA
```

| File | Page |
|------|------|
| `index.html` | Home |
| `sponsors/index.html` | Sponsors |
| `sponsors/how-to/index.html` | How to sponsor |
| `docs/index.html` | Docs landing |
| `docs/fll-2025-2026/index.html` | FLL Unearthed season docs |
| `media/index.html` | Media gallery |

The footer is duplicated inline on every page rather than shared from a template, so each file needed the same edit. The new text sits on a second line inside the existing `.footer-left` block via `<br>`, so it inherits the current muted footer styling and needs no CSS changes — `.footer-inner` already wraps and centre-aligns at the 768px breakpoint.

ABN verified against the [ABR record](https://abr.business.gov.au/ABN/View?abn=41535175584).

## Notes

- Rendering was reasoned about from the existing CSS rather than confirmed in a browser, so a quick visual check of the footer on mobile widths is worth doing before merge.
- There is an existing `copilot/add-lebob-robotics-abn` branch on the remote that may overlap with this change — worth comparing so the ABN isn't added twice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQQyTDVs7uBz67fVvNBCJ2)_